### PR TITLE
feat: use react-query and support model selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.84.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2"
@@ -22,5 +23,6 @@
     "tailwindcss": "^3.3.2",
     "typescript": "^5.2.2",
     "vite": "^4.4.9"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   onModelChange,
 }) => {
   return (
-    <div className="w-72 border-l border-gray-200 bg-white flex flex-col hidden lg:flex">
+    <div className="w-72 border-r border-gray-200 bg-white flex flex-col hidden lg:flex">
       {/* New chat and model selection */}
       <div className="p-4 border-b flex flex-col space-y-2">
         <button

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './index.css';
 import { AuthProvider } from './contexts/AuthContext';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <AuthProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -2,6 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import Sidebar from '../components/Sidebar';
 import ChatWindow from '../components/ChatWindow';
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 interface Conversation {
   id: string;
@@ -17,189 +22,180 @@ interface Message {
 const Chat: React.FC = () => {
   const { token } = useAuth();
   const baseUrl = import.meta.env.VITE_API_URL;
+  const queryClient = useQueryClient();
 
-  const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [currentConversationId, setCurrentConversationId] = useState<string | null>(null);
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [models, setModels] = useState<string[]>([]);
+  const [currentConversationId, setCurrentConversationId] = useState<string | null>(
+    null,
+  );
   const [selectedModel, setSelectedModel] = useState<string>('');
   const [searchTerm, setSearchTerm] = useState('');
-  const [loadingReply, setLoadingReply] = useState(false);
 
-  // Fetch available models and conversations on mount
-  useEffect(() => {
-    const fetchInitialData = async () => {
-      try {
-        // fetch models
-        const modelRes = await fetch(`${baseUrl}/v1/models`);
-        if (modelRes.ok) {
-          const data = await modelRes.json();
-          // Data shape may vary; attempt to extract ids
-          const modelIds: string[] = Array.isArray((data as any).data)
-            ? (data as any).data.map((m: any) => m.id)
-            : [];
-          setModels(modelIds);
-          if (modelIds.length > 0) setSelectedModel(modelIds[0]);
-        }
-        // fetch conversations
-        const convRes = await fetch(`${baseUrl}/conversations`, {
-          headers: token
-            ? {
-                'Authorization': `Bearer ${token}`,
-              }
-            : {},
-        });
-        if (convRes.ok) {
-          const convs = await convRes.json();
-          setConversations(convs);
-          if (convs.length > 0) {
-            setCurrentConversationId(convs[0].id);
-          }
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    };
-    fetchInitialData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Fetch messages whenever the current conversation changes
-  useEffect(() => {
-    const fetchMessages = async () => {
-      if (!currentConversationId) {
-        setMessages([]);
-        return;
-      }
-      try {
-        const res = await fetch(`${baseUrl}/conversations/${currentConversationId}`, {
-          headers: token
-            ? {
-                'Authorization': `Bearer ${token}`,
-              }
-            : {},
-        });
-        if (res.ok) {
-          const data = await res.json();
-          const msgs = Array.isArray(data.messages) ? data.messages : [];
-          setMessages(msgs);
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    };
-    fetchMessages();
-  }, [currentConversationId, baseUrl, token]);
-
-  // Create a new conversation and set it as active
-  const handleNewChat = async () => {
-    try {
-      const res = await fetch(`${baseUrl}/conversations`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({ title: null }),
-      });
-      if (res.ok) {
-        const conv: Conversation = await res.json();
-        setConversations((prev) => [...prev, conv]);
-        setCurrentConversationId(conv.id);
-        setMessages([]);
-      }
-    } catch (err) {
-      console.error(err);
-    }
+  // --- Models ---------------------------------------------------------------
+  const fetchModels = async (): Promise<string[]> => {
+    const res = await fetch(`${baseUrl}/v1/models`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) throw new Error('Failed to fetch models');
+    const data = await res.json();
+    return Array.isArray((data as any).data)
+      ? (data as any).data.map((m: any) => m.id)
+      : [];
   };
 
-  // Send a user message and fetch assistant response
-  const handleSendMessage = async (content: string) => {
-    if (!selectedModel) return;
-    setLoadingReply(true);
-    let conversationId = currentConversationId;
-    try {
-      // If no conversation yet, create one
+  const { data: models = [] } = useQuery([
+    'models',
+    token,
+  ], fetchModels, {
+    enabled: !!token,
+  });
+
+  useEffect(() => {
+    if (models.length > 0 && !selectedModel) {
+      setSelectedModel(models[0]);
+    }
+  }, [models, selectedModel]);
+
+  // --- Conversations -------------------------------------------------------
+  const fetchConversations = async (): Promise<Conversation[]> => {
+    const res = await fetch(`${baseUrl}/conversations`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) throw new Error('Failed to fetch conversations');
+    return res.json();
+  };
+
+  const { data: conversations = [] } = useQuery([
+    'conversations',
+    token,
+  ], fetchConversations, {
+    enabled: !!token,
+  });
+
+  useEffect(() => {
+    if (!currentConversationId && conversations.length > 0) {
+      setCurrentConversationId(conversations[0].id);
+    }
+  }, [conversations, currentConversationId]);
+
+  // --- Messages ------------------------------------------------------------
+  const fetchMessages = async (): Promise<Message[]> => {
+    if (!currentConversationId) return [];
+    const res = await fetch(`${baseUrl}/conversations/${currentConversationId}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) throw new Error('Failed to fetch messages');
+    const data = await res.json();
+    return Array.isArray(data.messages) ? data.messages : [];
+  };
+
+  const { data: messages = [] } = useQuery(
+    ['messages', currentConversationId, token],
+    fetchMessages,
+    { enabled: !!currentConversationId },
+  );
+
+  // --- Mutations -----------------------------------------------------------
+  const createConversation = async (): Promise<Conversation> => {
+    const res = await fetch(`${baseUrl}/conversations`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ title: null }),
+    });
+    if (!res.ok) throw new Error('Failed to create conversation');
+    return res.json();
+  };
+
+  const createConversationMutation = useMutation(createConversation, {
+    onSuccess: (conv) => {
+      queryClient.invalidateQueries(['conversations', token]);
+      setCurrentConversationId(conv.id);
+      queryClient.setQueryData(['messages', conv.id, token], []);
+    },
+  });
+
+  const sendMessageMutation = useMutation(
+    async (content: string) => {
+      let conversationId = currentConversationId;
       if (!conversationId) {
-        const res = await fetch(`${baseUrl}/conversations`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-          },
-          body: JSON.stringify({ title: null }),
-        });
-        if (res.ok) {
-          const conv: Conversation = await res.json();
-          setConversations((prev) => [...prev, conv]);
-          conversationId = conv.id;
-          setCurrentConversationId(conv.id);
-        }
+        const conv = await createConversation();
+        conversationId = conv.id;
+        setCurrentConversationId(conv.id);
+        queryClient.invalidateQueries(['conversations', token]);
+        queryClient.setQueryData(['messages', conv.id, token], []);
       }
-      if (!conversationId) return;
-      // Immediately add user message to state
+
       const userMsg: Message = {
         id: `${Date.now()}-user`,
         role: 'user',
         content,
       };
-      setMessages((prev) => [...prev, userMsg]);
-      // Persist user message via API
+      queryClient.setQueryData<Message[]>(
+        ['messages', conversationId, token],
+        (old = []) => [...old, userMsg],
+      );
+
       await fetch(`${baseUrl}/conversations/${conversationId}/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({ role: 'user', content }),
       });
-      // Request assistant reply via chat completions
+
       const res = await fetch(`${baseUrl}/v1/chat/completions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-Conversation-Id': conversationId,
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({
           model: selectedModel,
-          messages: [
-            {
-              role: 'user',
-              content,
-            },
-          ],
+          messages: [{ role: 'user', content }],
         }),
       });
+
       let assistantContent = '';
       if (res.ok) {
         const data = await res.json();
-        // openai‑compatible format: data.choices[0].message.content
         const choices = (data as any).choices;
         if (Array.isArray(choices) && choices[0]?.message?.content) {
           assistantContent = choices[0].message.content;
         }
       }
-      // Append assistant message locally
+
       const assistantMsg: Message = {
         id: `${Date.now()}-assistant`,
         role: 'assistant',
         content: assistantContent,
       };
-      setMessages((prev) => [...prev, assistantMsg]);
-      // Persist assistant message
+      queryClient.setQueryData<Message[]>(
+        ['messages', conversationId, token],
+        (old = []) => [...old, assistantMsg],
+      );
+
       await fetch(`${baseUrl}/conversations/${conversationId}/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({ role: 'assistant', content: assistantContent }),
       });
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoadingReply(false);
-    }
+    },
+  );
+
+  const handleNewChat = () => {
+    createConversationMutation.mutate();
+  };
+
+  const handleSendMessage = (content: string) => {
+    if (!selectedModel) return;
+    sendMessageMutation.mutate(content);
   };
 
   // Filter conversations based on search term
@@ -210,6 +206,18 @@ const Chat: React.FC = () => {
 
   return (
     <div className="h-screen flex bg-gray-50">
+      {/* Sidebar on large screens */}
+      <Sidebar
+        conversations={filteredConversations}
+        currentConversationId={currentConversationId}
+        onSelectConversation={(id) => setCurrentConversationId(id)}
+        onNewChat={handleNewChat}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        models={models}
+        selectedModel={selectedModel}
+        onModelChange={setSelectedModel}
+      />
       <div className="flex flex-col flex-1">
         {/* Top bar for small screens */}
         <div className="lg:hidden p-4 border-b bg-white space-y-2">
@@ -247,24 +255,13 @@ const Chat: React.FC = () => {
           <ChatWindow
             messages={messages}
             onSend={handleSendMessage}
-            loadingReply={loadingReply}
+            loadingReply={sendMessageMutation.isLoading}
           />
         </div>
       </div>
-      {/* Sidebar on large screens */}
-      <Sidebar
-        conversations={filteredConversations}
-        currentConversationId={currentConversationId}
-        onSelectConversation={(id) => setCurrentConversationId(id)}
-        onNewChat={handleNewChat}
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-        models={models}
-        selectedModel={selectedModel}
-        onModelChange={setSelectedModel}
-      />
     </div>
   );
 };
 
 export default Chat;
+

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useMutation } from '@tanstack/react-query';
 
 const Login: React.FC = () => {
   const { login } = useAuth();
@@ -8,20 +9,16 @@ const Login: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const loginMutation = useMutation({
+    mutationFn: () => login(email, password),
+    onSuccess: () => navigate('/chat'),
+    onError: (err: any) => setError((err as Error).message),
+  });
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    setLoading(true);
-    try {
-      await login(email, password);
-      navigate('/chat');
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setLoading(false);
-    }
+    loginMutation.mutate();
   };
 
   return (
@@ -62,10 +59,10 @@ const Login: React.FC = () => {
           </div>
           <button
             type="submit"
-            disabled={loading}
+            disabled={loginMutation.isLoading}
             className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none"
           >
-            {loading ? 'Signing in...' : 'Sign In'}
+            {loginMutation.isLoading ? 'Signing in...' : 'Sign In'}
           </button>
         </form>
         <p className="mt-4 text-center text-sm text-gray-600">

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useMutation } from '@tanstack/react-query';
 
 const Signup: React.FC = () => {
   const { signup } = useAuth();
@@ -8,20 +9,16 @@ const Signup: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const signupMutation = useMutation({
+    mutationFn: () => signup(email, password),
+    onSuccess: () => navigate('/chat'),
+    onError: (err: any) => setError((err as Error).message),
+  });
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    setLoading(true);
-    try {
-      await signup(email, password);
-      navigate('/chat');
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setLoading(false);
-    }
+    signupMutation.mutate();
   };
 
   return (
@@ -62,10 +59,10 @@ const Signup: React.FC = () => {
           </div>
           <button
             type="submit"
-            disabled={loading}
+            disabled={signupMutation.isLoading}
             className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none"
           >
-            {loading ? 'Signing up...' : 'Sign Up'}
+            {signupMutation.isLoading ? 'Signing up...' : 'Sign Up'}
           </button>
         </form>
         <p className="mt-4 text-center text-sm text-gray-600">

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,6 +357,18 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz#47d2bf4cef6d470b22f5831b420f8964e0bf755f"
   integrity sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==
 
+"@tanstack/query-core@5.83.1":
+  version "5.83.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.83.1.tgz#eed82970b30cb24536f561613b5630e03d349628"
+  integrity sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==
+
+"@tanstack/react-query@^5.84.2":
+  version "5.84.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.84.2.tgz#008a8cd26b1e258f87f54cf00cbae14e9c3c84d2"
+  integrity sha512-cZadySzROlD2+o8zIfbD978p0IphuQzRWiiH3I2ugnTmz4jbjc0+TdibpwqxlzynEen8OulgAg+rzdNF37s7XQ==
+  dependencies:
+    "@tanstack/query-core" "5.83.1"
+
 "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -1137,16 +1149,7 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1164,14 +1167,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## Summary
- move chat sidebar to the left and provide model selector
- fetch data through React Query with bearer token headers
- use React Query mutations for auth flows

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6898102f9ff883219a7b01bdd35257e9