### PR TITLE
refactor: centralize auth fetch

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,22 @@
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Simple wrapper around fetch that automatically prefixes the API base URL
+ * and attaches the bearer token when available. This acts as middleware so
+ * that individual components don't need to repeat the authentication logic.
+ */
+const useApi = () => {
+  const { token } = useAuth();
+  const baseUrl = import.meta.env.VITE_API_URL;
+
+  return (path: string, options: RequestInit = {}) => {
+    const headers = new Headers(options.headers || {});
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    return fetch(`${baseUrl}${path}`, { ...options, headers });
+  };
+};
+
+export default useApi;

--- a/src/hooks/useApiCollection.ts
+++ b/src/hooks/useApiCollection.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQueryClient, QueryKey } from '@tanstack/react-query';
+import useApiQuery from './useApiQuery';
+import useApi from './useApi';
+
+interface UseApiCollectionOptions<T> {
+  path: string;
+  getId: (item: T) => string | number;
+  enabled?: boolean;
+  transform?: (data: any) => T[];
+}
+
+interface UpdateArgs<T> {
+  id: string | number;
+  data: Partial<T>;
+}
+
+const useApiCollection = <T>(
+  key: QueryKey,
+  { path, getId, enabled = true, transform }: UseApiCollectionOptions<T>,
+) => {
+  const apiFetch = useApi();
+  const queryClient = useQueryClient();
+
+  const query = useApiQuery<T[]>(key, { path, enabled, transform });
+
+  const addMutation = useMutation(
+    async (item: Partial<T>) => {
+      const res = await apiFetch(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(item),
+      });
+      if (!res.ok) throw new Error('Failed to add item');
+      return res.json();
+    },
+    {
+      onSuccess: (newItem: T) => {
+        queryClient.setQueryData<T[]>(key, (old = []) => [...old, newItem]);
+      },
+    },
+  );
+
+  const updateMutation = useMutation(
+    async ({ id, data }: UpdateArgs<T>) => {
+      const res = await apiFetch(`${path}/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error('Failed to update item');
+      return res.json();
+    },
+    {
+      onSuccess: (updatedItem: T) => {
+        queryClient.setQueryData<T[]>(key, (old = []) =>
+          old.map((item) => (getId(item) === getId(updatedItem) ? updatedItem : item)),
+        );
+      },
+    },
+  );
+
+  const removeMutation = useMutation(
+    async (id: string | number) => {
+      const res = await apiFetch(`${path}/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to remove item');
+      return id;
+    },
+    {
+      onSuccess: (id) => {
+        queryClient.setQueryData<T[]>(key, (old = []) =>
+          old.filter((item) => getId(item) !== id),
+        );
+      },
+    },
+  );
+
+  return {
+    ...query,
+    addItem: addMutation.mutateAsync,
+    updateItem: updateMutation.mutateAsync,
+    removeItem: removeMutation.mutateAsync,
+    adding: addMutation.isLoading,
+    updating: updateMutation.isLoading,
+    removing: removeMutation.isLoading,
+  };
+};
+
+export default useApiCollection;

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,0 +1,28 @@
+import { useQuery, UseQueryOptions, QueryKey } from '@tanstack/react-query';
+import useApi from './useApi';
+
+interface ApiQueryOptions<T> extends Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'> {
+  path: string;
+  transform?: (data: any) => T;
+  init?: RequestInit;
+}
+
+const useApiQuery = <T = unknown>(
+  key: QueryKey,
+  { path, transform, init, ...options }: ApiQueryOptions<T>,
+) => {
+  const apiFetch = useApi();
+
+  return useQuery<T>(
+    key,
+    async () => {
+      const res = await apiFetch(path, init);
+      if (!res.ok) throw new Error('Failed to fetch');
+      const data = await res.json();
+      return transform ? transform(data) : data;
+    },
+    options,
+  );
+};
+
+export default useApiQuery;


### PR DESCRIPTION
## Summary
- add `useApi` hook that injects auth token into fetch calls
- add `useApiQuery` hook wrapping React Query with authenticated fetch
- refactor chat page queries to use `useApiQuery` instead of manual fetchers
- add `useApiCollection` hook for CRUD-style lists and adopt it for conversations

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a152ac9a6483218bbf718332f011a1