### PR TITLE
feat: add file upload attachments to chat

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -1,14 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
-
-interface Message {
-  id: string;
-  role: 'user' | 'assistant' | 'system' | 'tool';
-  content: string;
-}
+import useApi from '../hooks/useApi';
+import type { Message } from '../models/Message';
+import type { File as FileModel } from '../models/File';
 
 interface ChatWindowProps {
   messages: Message[];
-  onSend: (content: string) => void;
+  onSend: (content: string, files: FileModel[]) => void;
   loadingReply: boolean;
 }
 
@@ -16,14 +13,58 @@ interface ChatWindowProps {
  * Displays chat messages and a composer for sending new messages.
  */
 const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply }) => {
+  const apiFetch = useApi();
   const [input, setInput] = useState('');
+  const [files, setFiles] = useState<FileModel[]>([]);
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFiles = async (fileList: FileList) => {
+    const arr = Array.from(fileList);
+    for (const file of arr) {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await apiFetch('/upload/file', {
+        method: 'POST',
+        body: formData,
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setFiles((prev) => [
+          ...prev,
+          { id: data.id, name: data.name || file.name, public_url: data.public_url },
+        ]);
+      }
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      handleFiles(e.target.files);
+      e.target.value = '';
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLTextAreaElement>) => {
+    e.preventDefault();
+    if (e.dataTransfer.files) {
+      handleFiles(e.dataTransfer.files);
+    }
+  };
+
+  const handleRemoveFile = async (id: string) => {
+    await apiFetch(`/files/${id}`, {
+      method: 'DELETE',
+    });
+    setFiles((prev) => prev.filter((f) => f.id !== id));
+  };
 
   const handleSend = () => {
     const trimmed = input.trim();
     if (!trimmed) return;
-    onSend(trimmed);
+    onSend(trimmed, files);
     setInput('');
+    setFiles([]);
   };
 
   // Scroll to bottom whenever messages change
@@ -40,14 +81,32 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply 
             key={msg.id}
             className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
           >
-            <div
-              className={`max-w-sm p-3 rounded-lg text-sm whitespace-pre-wrap ${
-                msg.role === 'user'
-                  ? 'bg-indigo-600 text-white rounded-br-none'
-                  : 'bg-gray-200 text-gray-900 rounded-bl-none'
-              }`}
-            >
-              {msg.content}
+            <div>
+              <div
+                className={`max-w-sm p-3 rounded-lg text-sm whitespace-pre-wrap ${
+                  msg.role === 'user'
+                    ? 'bg-indigo-600 text-white rounded-br-none'
+                    : 'bg-gray-200 text-gray-900 rounded-bl-none'
+                }`}
+              >
+                {msg.content}
+              </div>
+              {msg.files && msg.files.length > 0 && (
+                <div className="mt-1 text-xs">
+                  {msg.files.map((file) => (
+                    <div key={file.id}>
+                      <a
+                        href={file.public_url}
+                        className="underline text-blue-600"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {file.name}
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         ))}
@@ -62,6 +121,24 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply 
       </div>
       {/* Composer */}
       <div className="border-t border-gray-200 p-4 bg-white">
+        {files.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-2">
+            {files.map((f) => (
+              <div
+                key={f.id}
+                className="flex items-center space-x-1 bg-gray-100 px-2 py-1 rounded"
+              >
+                <span className="text-xs">{f.name}</span>
+                <button
+                  onClick={() => handleRemoveFile(f.id)}
+                  className="text-xs text-red-500"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="flex items-center space-x-2">
           <textarea
             className="flex-1 resize-none border border-gray-300 rounded-md p-2 text-sm focus:ring-indigo-500 focus:border-indigo-500"
@@ -75,7 +152,23 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply 
                 handleSend();
               }
             }}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={handleDrop}
           />
+          <input
+            type="file"
+            multiple
+            ref={fileInputRef}
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="bg-gray-200 px-2 py-2 rounded-md text-sm"
+          >
+            Attach
+          </button>
           <button
             onClick={handleSend}
             disabled={!input.trim() || loadingReply}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,22 @@
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Simple wrapper around fetch that automatically prefixes the API base URL
+ * and attaches the bearer token when available. This acts as middleware so
+ * that individual components don't need to repeat the authentication logic.
+ */
+const useApi = () => {
+  const { token } = useAuth();
+  const baseUrl = import.meta.env.VITE_API_URL;
+
+  return (path: string, options: RequestInit = {}) => {
+    const headers = new Headers(options.headers || {});
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    return fetch(`${baseUrl}${path}`, { ...options, headers });
+  };
+};
+
+export default useApi;

--- a/src/hooks/useApiCollection.ts
+++ b/src/hooks/useApiCollection.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQueryClient, QueryKey } from '@tanstack/react-query';
+import useApiQuery from './useApiQuery';
+import useApi from './useApi';
+
+interface UseApiCollectionOptions<T> {
+  path: string;
+  getId: (item: T) => string | number;
+  enabled?: boolean;
+  transform?: (data: any) => T[];
+}
+
+interface UpdateArgs<T> {
+  id: string | number;
+  data: Partial<T>;
+}
+
+const useApiCollection = <T>(
+  key: QueryKey,
+  { path, getId, enabled = true, transform }: UseApiCollectionOptions<T>,
+) => {
+  const apiFetch = useApi();
+  const queryClient = useQueryClient();
+
+  const query = useApiQuery<T[]>(key, { path, enabled, transform });
+
+  const addMutation = useMutation(
+    async (item: Partial<T>) => {
+      const res = await apiFetch(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(item),
+      });
+      if (!res.ok) throw new Error('Failed to add item');
+      return res.json();
+    },
+    {
+      onSuccess: (newItem: T) => {
+        queryClient.setQueryData<T[]>(key, (old = []) => [...old, newItem]);
+      },
+    },
+  );
+
+  const updateMutation = useMutation(
+    async ({ id, data }: UpdateArgs<T>) => {
+      const res = await apiFetch(`${path}/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error('Failed to update item');
+      return res.json();
+    },
+    {
+      onSuccess: (updatedItem: T) => {
+        queryClient.setQueryData<T[]>(key, (old = []) =>
+          old.map((item) => (getId(item) === getId(updatedItem) ? updatedItem : item)),
+        );
+      },
+    },
+  );
+
+  const removeMutation = useMutation(
+    async (id: string | number) => {
+      const res = await apiFetch(`${path}/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to remove item');
+      return id;
+    },
+    {
+      onSuccess: (id) => {
+        queryClient.setQueryData<T[]>(key, (old = []) =>
+          old.filter((item) => getId(item) !== id),
+        );
+      },
+    },
+  );
+
+  return {
+    ...query,
+    addItem: addMutation.mutateAsync,
+    updateItem: updateMutation.mutateAsync,
+    removeItem: removeMutation.mutateAsync,
+    adding: addMutation.isLoading,
+    updating: updateMutation.isLoading,
+    removing: removeMutation.isLoading,
+  };
+};
+
+export default useApiCollection;

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,0 +1,28 @@
+import { useQuery, UseQueryOptions, QueryKey } from '@tanstack/react-query';
+import useApi from './useApi';
+
+interface ApiQueryOptions<T> extends Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'> {
+  path: string;
+  transform?: (data: any) => T;
+  init?: RequestInit;
+}
+
+const useApiQuery = <T = unknown>(
+  key: QueryKey,
+  { path, transform, init, ...options }: ApiQueryOptions<T>,
+) => {
+  const apiFetch = useApi();
+
+  return useQuery<T>(
+    key,
+    async () => {
+      const res = await apiFetch(path, init);
+      if (!res.ok) throw new Error('Failed to fetch');
+      const data = await res.json();
+      return transform ? transform(data) : data;
+    },
+    options,
+  );
+};
+
+export default useApiQuery;

--- a/src/models/Conversation.ts
+++ b/src/models/Conversation.ts
@@ -1,0 +1,8 @@
+import type { Message } from './Message';
+
+export interface Conversation {
+  id: string;
+  title?: string | null;
+  messages?: Message[];
+}
+

--- a/src/models/File.ts
+++ b/src/models/File.ts
@@ -1,0 +1,6 @@
+export interface File {
+  id: string;
+  name: string;
+  public_url: string;
+}
+

--- a/src/models/Message.ts
+++ b/src/models/Message.ts
@@ -1,0 +1,9 @@
+import type { File } from './File';
+
+export interface Message {
+  id: string;
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  files?: File[];
+}
+

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -2,26 +2,17 @@ import React, { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import Sidebar from '../components/Sidebar';
 import ChatWindow from '../components/ChatWindow';
-import {
-  useQuery,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query';
-
-interface Conversation {
-  id: string;
-  title?: string | null;
-}
-
-interface Message {
-  id: string;
-  role: 'user' | 'assistant' | 'system' | 'tool';
-  content: string;
-}
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useApi from '../hooks/useApi';
+import useApiQuery from '../hooks/useApiQuery';
+import useApiCollection from '../hooks/useApiCollection';
+import type { Conversation } from '../models/Conversation';
+import type { Message } from '../models/Message';
+import type { File as FileModel } from '../models/File';
 
 const Chat: React.FC = () => {
   const { token } = useAuth();
-  const baseUrl = import.meta.env.VITE_API_URL;
+  const apiFetch = useApi();
   const queryClient = useQueryClient();
 
   const [currentConversationId, setCurrentConversationId] = useState<string | null>(
@@ -31,22 +22,11 @@ const Chat: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
 
   // --- Models ---------------------------------------------------------------
-  const fetchModels = async (): Promise<string[]> => {
-    const res = await fetch(`${baseUrl}/v1/models`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
-    if (!res.ok) throw new Error('Failed to fetch models');
-    const data = await res.json();
-    return Array.isArray((data as any).data)
-      ? (data as any).data.map((m: any) => m.id)
-      : [];
-  };
-
-  const { data: models = [] } = useQuery([
-    'models',
-    token,
-  ], fetchModels, {
+  const { data: models = [] } = useApiQuery<string[]>(['models', token], {
+    path: '/v1/models',
     enabled: !!token,
+    transform: (data: any) =>
+      Array.isArray(data.data) ? data.data.map((m: any) => m.id) : [],
   });
 
   useEffect(() => {
@@ -56,20 +36,16 @@ const Chat: React.FC = () => {
   }, [models, selectedModel]);
 
   // --- Conversations -------------------------------------------------------
-  const fetchConversations = async (): Promise<Conversation[]> => {
-    const res = await fetch(`${baseUrl}/conversations`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
-    if (!res.ok) throw new Error('Failed to fetch conversations');
-    return res.json();
-  };
-
-  const { data: conversations = [] } = useQuery([
-    'conversations',
-    token,
-  ], fetchConversations, {
-    enabled: !!token,
-  });
+  const { data: conversations = [], addItem: addConversation } = useApiCollection<
+    Conversation
+  >(
+    ['conversations', token],
+    {
+      path: '/conversations',
+      enabled: !!token,
+      getId: (c) => c.id,
+    },
+  );
 
   useEffect(() => {
     if (!currentConversationId && conversations.length > 0) {
@@ -78,52 +54,24 @@ const Chat: React.FC = () => {
   }, [conversations, currentConversationId]);
 
   // --- Messages ------------------------------------------------------------
-  const fetchMessages = async (): Promise<Message[]> => {
-    if (!currentConversationId) return [];
-    const res = await fetch(`${baseUrl}/conversations/${currentConversationId}`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
-    if (!res.ok) throw new Error('Failed to fetch messages');
-    const data = await res.json();
-    return Array.isArray(data.messages) ? data.messages : [];
-  };
-
-  const { data: messages = [] } = useQuery(
+  const { data: messages = [] } = useApiQuery<Message[]>(
     ['messages', currentConversationId, token],
-    fetchMessages,
-    { enabled: !!currentConversationId },
+    {
+      path: `/conversations/${currentConversationId}`,
+      enabled: !!currentConversationId,
+      transform: (data: any) =>
+        Array.isArray(data.messages) ? data.messages : [],
+    },
   );
 
   // --- Mutations -----------------------------------------------------------
-  const createConversation = async (): Promise<Conversation> => {
-    const res = await fetch(`${baseUrl}/conversations`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      body: JSON.stringify({ title: null }),
-    });
-    if (!res.ok) throw new Error('Failed to create conversation');
-    return res.json();
-  };
-
-  const createConversationMutation = useMutation(createConversation, {
-    onSuccess: (conv) => {
-      queryClient.invalidateQueries(['conversations', token]);
-      setCurrentConversationId(conv.id);
-      queryClient.setQueryData(['messages', conv.id, token], []);
-    },
-  });
-
   const sendMessageMutation = useMutation(
-    async (content: string) => {
+    async ({ content, files }: { content: string; files: FileModel[] }) => {
       let conversationId = currentConversationId;
       if (!conversationId) {
-        const conv = await createConversation();
+        const conv = await addConversation({ title: null });
         conversationId = conv.id;
         setCurrentConversationId(conv.id);
-        queryClient.invalidateQueries(['conversations', token]);
         queryClient.setQueryData(['messages', conv.id, token], []);
       }
 
@@ -131,31 +79,30 @@ const Chat: React.FC = () => {
         id: `${Date.now()}-user`,
         role: 'user',
         content,
+        files,
       };
       queryClient.setQueryData<Message[]>(
         ['messages', conversationId, token],
         (old = []) => [...old, userMsg],
       );
 
-      await fetch(`${baseUrl}/conversations/${conversationId}/messages`, {
+      await apiFetch(`/conversations/${conversationId}/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
-        body: JSON.stringify({ role: 'user', content }),
+        body: JSON.stringify({ role: 'user', content, file_ids: files.map((f) => f.id) }),
       });
 
-      const res = await fetch(`${baseUrl}/v1/chat/completions`, {
+      const res = await apiFetch('/v1/chat/completions', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-Conversation-Id': conversationId,
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({
           model: selectedModel,
-          messages: [{ role: 'user', content }],
+          messages: [{ role: 'user', content, file_ids: files.map((f) => f.id) }],
         }),
       });
 
@@ -178,24 +125,25 @@ const Chat: React.FC = () => {
         (old = []) => [...old, assistantMsg],
       );
 
-      await fetch(`${baseUrl}/conversations/${conversationId}/messages`, {
+      await apiFetch(`/conversations/${conversationId}/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({ role: 'assistant', content: assistantContent }),
       });
     },
   );
 
-  const handleNewChat = () => {
-    createConversationMutation.mutate();
+  const handleNewChat = async () => {
+    const conv = await addConversation({ title: null });
+    setCurrentConversationId(conv.id);
+    queryClient.setQueryData(['messages', conv.id, token], []);
   };
 
-  const handleSendMessage = (content: string) => {
+  const handleSendMessage = (content: string, files: FileModel[]) => {
     if (!selectedModel) return;
-    sendMessageMutation.mutate(content);
+    sendMessageMutation.mutate({ content, files });
   };
 
   // Filter conversations based on search term


### PR DESCRIPTION
## Summary
- support uploading files with drag & drop and attachment UI
- use shared API hooks for models, conversations and messages
- send file IDs with messages and show attached files in chat

## Testing
- `git fetch origin main` (fails: repository has no `origin` remote)
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a154e31e908321922770e14d4f9436