### PR TITLE
feat: add archive discussion controls

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -7,17 +7,33 @@ interface ChatWindowProps {
   messages: Message[];
   onSend: (content: string, files: FileModel[]) => void;
   loadingReply: boolean;
+  conversationTitle: string;
+  isArchived: boolean;
+  onRenameConversation: (title: string) => void;
+  onToggleArchive: () => void;
+  onDeleteConversation: () => void;
 }
 
 /**
  * Displays chat messages and a composer for sending new messages.
  */
-const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply }) => {
+const ChatWindow: React.FC<ChatWindowProps> = ({
+  messages,
+  onSend,
+  loadingReply,
+  conversationTitle,
+  isArchived,
+  onRenameConversation,
+  onToggleArchive,
+  onDeleteConversation,
+}) => {
   const apiFetch = useApi();
   const [input, setInput] = useState('');
   const [files, setFiles] = useState<FileModel[]>([]);
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
 
   const handleFiles = async (fileList: FileList) => {
     const arr = Array.from(fileList);
@@ -74,6 +90,68 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply 
 
   return (
     <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="border-b p-4 flex items-center justify-between bg-white">
+        {editingTitle ? (
+          <div className="flex items-center space-x-1">
+            <input
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              className="border border-gray-300 rounded px-1 text-sm"
+              autoFocus
+            />
+            <button
+              onClick={() => {
+                onRenameConversation(editTitle.trim());
+                setEditingTitle(false);
+              }}
+              className="text-green-600 text-xs"
+            >
+              ✓
+            </button>
+            <button
+              onClick={() => {
+                setEditingTitle(false);
+                setEditTitle('');
+              }}
+              className="text-red-600 text-xs"
+            >
+              ✕
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center space-x-2">
+            <h2 className="truncate text-sm font-medium">
+              {conversationTitle}
+            </h2>
+            <button
+              onClick={() => {
+                setEditingTitle(true);
+                setEditTitle(conversationTitle);
+              }}
+              className="text-gray-500 hover:text-gray-700 text-xs"
+            >
+              ✎
+            </button>
+          </div>
+        )}
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={onToggleArchive}
+            className="text-gray-500 hover:text-gray-700 text-xs"
+            title={isArchived ? 'Unarchive' : 'Archive'}
+          >
+            {isArchived ? '📤' : '🗄'}
+          </button>
+          <button
+            onClick={onDeleteConversation}
+            className="text-gray-500 hover:text-gray-700 text-xs"
+            title="Delete"
+          >
+            🗑
+          </button>
+        </div>
+      </div>
       {/* Messages area */}
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((msg) => (
@@ -183,3 +261,4 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply 
 };
 
 export default ChatWindow;
+

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 interface ConversationItem {
   id: string;
   title?: string | null;
+  archived?: boolean;
 }
 
 interface SidebarProps {
@@ -11,6 +12,8 @@ interface SidebarProps {
   onSelectConversation: (id: string) => void;
   onNewChat: () => void;
   onRenameConversation: (id: string, title: string) => void;
+  onToggleArchiveConversation: (id: string, archived: boolean) => void;
+  onDeleteConversation: (id: string) => void;
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   models: string[];
@@ -24,6 +27,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   onSelectConversation,
   onNewChat,
   onRenameConversation,
+  onToggleArchiveConversation,
+  onDeleteConversation,
   searchTerm,
   setSearchTerm,
   models,
@@ -137,18 +142,42 @@ const Sidebar: React.FC<SidebarProps> = ({
                     </button>
                   </div>
                 ) : (
-                  <>
-                    <span className="truncate">{title}</span>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        startEditing(conv.id, title);
-                      }}
-                      className="opacity-0 group-hover:opacity-100 ml-2 text-gray-500 hover:text-gray-700 text-xs"
+                  <div className="flex items-center justify-between w-full">
+                    <span
+                      className={`truncate ${conv.archived ? 'text-gray-400 italic' : ''}`}
                     >
-                      ✎
-                    </button>
-                  </>
+                      {title}
+                    </span>
+                    <div className="flex items-center space-x-1 opacity-0 group-hover:opacity-100 ml-2">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          startEditing(conv.id, title);
+                        }}
+                        className="text-gray-500 hover:text-gray-700 text-xs"
+                      >
+                        ✎
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onToggleArchiveConversation(conv.id, !conv.archived);
+                        }}
+                        className="text-gray-500 hover:text-gray-700 text-xs"
+                      >
+                        {conv.archived ? '📤' : '🗄'}
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDeleteConversation(conv.id);
+                        }}
+                        className="text-gray-500 hover:text-gray-700 text-xs"
+                      >
+                        🗑
+                      </button>
+                    </div>
+                  </div>
                 )}
               </li>
             );

--- a/src/models/Conversation.ts
+++ b/src/models/Conversation.ts
@@ -3,6 +3,7 @@ import type { Message } from './Message';
 export interface Conversation {
   id: string;
   title?: string | null;
+  archived?: boolean;
   messages?: Message[];
 }
 


### PR DESCRIPTION
## Summary
- support archived state on conversations
- show editable conversation title with archive and delete actions
- expose archive, unarchive and delete options in sidebar

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a1850ea4d08321ad1ec74442754b49