### PR TITLE
Stream replies after sending messages

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -110,7 +110,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ messages, onSend, loadingReply 
             </div>
           </div>
         ))}
-        {loadingReply && (
+        {loadingReply && messages[messages.length - 1]?.role !== 'assistant' && (
           <div className="flex justify-start">
             <div className="max-w-sm p-3 rounded-lg text-sm bg-gray-200 text-gray-900 rounded-bl-none italic opacity-75">
               Thinking...


### PR DESCRIPTION
## Summary
- Stream assistant replies by calling new `/conversations/:id/reply` endpoint after user messages
- Show “Thinking…” placeholder only until assistant reply starts

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68a185a79bb08321891fb2f7d9f057f1